### PR TITLE
fix(client): render the world at native resolution for smooth motion

### DIFF
--- a/game/client/src/core/render/present.rs
+++ b/game/client/src/core/render/present.rs
@@ -1,5 +1,6 @@
-//! The pixel-art present pipeline: the world renders to a fixed-zoom offscreen texture, which a
-//! fullscreen quad then upscales to the window. `fit` keeps the texture sized to the window, and the
+//! The pixel-art present pipeline: the world renders to a native-resolution offscreen texture (the
+//! camera's [`SCALE`] zoom magnifies the art, so motion stays smooth to the screen pixel), which a
+//! fullscreen quad then copies to the window. `fit` keeps the texture sized to the window, and the
 //! `Present` material applies a whole-screen [`ScreenTint`] any system can set.
 
 use bevy::camera::visibility::RenderLayers;
@@ -16,9 +17,13 @@ use super::camera::WorldCamera;
 
 // The fixed zoom: every tile is drawn this many logical pixels across on every device, so the world
 // looks the same size to every player. A larger display just frames more of the map — never bigger
-// tiles — and network AOI culling bounds what's actually streamed. (48 keeps a ~900px-tall view near
-// the game's long-standing 18-tiles-tall look, and being a multiple of TILE upscales crisply.)
+// tiles — and network AOI culling bounds what's actually streamed. A multiple of TILE keeps each
+// art-pixel an exact whole number of screen pixels, so nearest-neighbour magnification stays crisp.
 const TILE_SCREEN: f32 = 96.0;
+// Screen pixels per art-pixel — the camera's magnification. The world renders at native resolution and
+// the camera zooms by this, rather than rendering small and upscaling, so on-screen motion advances a
+// screen pixel at a time instead of a whole art-pixel (which staircased diagonal movement).
+pub(crate) const SCALE: f32 = TILE_SCREEN / TILE.0;
 const PRESENT_LAYER: usize = 1;
 
 #[derive(Component)]
@@ -77,8 +82,8 @@ pub(super) fn setup(
         RenderTarget::Image(target.clone().into()),
         Projection::Orthographic(OrthographicProjection {
             scaling_mode: ScalingMode::Fixed {
-                width: target_w as f32,
-                height: target_h as f32,
+                width: target_w as f32 / SCALE,
+                height: target_h as f32 / SCALE,
             },
             ..OrthographicProjection::default_2d()
         }),
@@ -142,8 +147,8 @@ pub(super) fn fit(
             && let Projection::Orthographic(ortho) = proj.as_mut()
         {
             ortho.scaling_mode = ScalingMode::Fixed {
-                width: target_w as f32,
-                height: target_h as f32,
+                width: target_w as f32 / SCALE,
+                height: target_h as f32 / SCALE,
             };
         }
     }
@@ -167,12 +172,12 @@ pub(super) fn apply_tint(
     }
 }
 
-// The render target is the visible world in native pixels: the window's logical size scaled down by
-// the fixed per-tile zoom, so the present step upscales each source pixel by the same factor on every
-// device. Even dimensions keep tile edges on whole texels; an odd one would draw seams between tiles.
+// The render target matches the window 1:1 (native resolution), so on-screen motion is smooth to the
+// pixel and the camera's SCALE zoom does the magnification. Even dimensions keep the centred view on
+// whole pixels; an odd one would split the centre pixel.
 pub(crate) fn target_size(window: &Window) -> (u32, u32) {
     let scaled = |logical: f32| {
-        let px = (logical * TILE.0 / TILE_SCREEN).round().max(2.0) as u32;
+        let px = logical.round().max(2.0) as u32;
         px + (px & 1)
     };
     let res = &window.resolution;

--- a/game/client/src/systems/view.rs
+++ b/game/client/src/systems/view.rs
@@ -17,7 +17,7 @@ use world::systems::player::session::MyClient;
 use crate::core::audio::Listener;
 use crate::core::render::TILE;
 use crate::core::render::camera::WorldCamera;
-use crate::core::render::present::target_size;
+use crate::core::render::present::{SCALE, target_size};
 use crate::core::render::screen::ToScreen;
 
 pub struct ViewPlugin;
@@ -49,9 +49,12 @@ fn track_player(
         return;
     };
     if let Ok(mut transform) = camera.single_mut() {
+        // Snap the camera to whole screen pixels so static tiles never shimmer. At native resolution one
+        // screen pixel is 1/SCALE of an art-pixel — far finer than the old whole-art-pixel snap, which
+        // is why the world no longer staircases under the camera.
         let at = center.to_screen();
-        transform.translation.x = at.x;
-        transform.translation.y = at.y;
+        transform.translation.x = (at.x * SCALE).round() / SCALE;
+        transform.translation.y = (at.y * SCALE).round() / SCALE;
     }
 }
 
@@ -63,15 +66,11 @@ fn camera_center(at: Pos<Tiles>, area_id: Id<AreaDef>, half: Vec2) -> Option<Pos
         (bounds.max().x - half.x).max(lo.x),
         (bounds.max().y - half.y).max(lo.y),
     );
-    Some(snap(at.clamp(lo, hi)))
+    Some(at.clamp(lo, hi))
 }
 
 fn view_half(window: &Window) -> Vec2 {
     let (w, h) = target_size(window);
-    Vec2::new(0.5 * w as f32 / TILE.0, 0.5 * h as f32 / TILE.0)
-}
-
-fn snap(p: Pos<Tiles>) -> Pos<Tiles> {
-    let axis = |t: f32| (t * TILE.0).round() / TILE.0;
-    Pos::new(axis(p.x), axis(p.y))
+    let per_tile = TILE.0 * SCALE;
+    Vec2::new(0.5 * w as f32 / per_tile, 0.5 * h as f32 / per_tile)
 }


### PR DESCRIPTION
The world rendered to a 1/6-size offscreen texture that was upscaled 6x by the present pass. Anything drawn into that low-res buffer could only move in whole-texel steps — 6 screen pixels at the current zoom. On cardinal headings one axis steps regularly and reads as smooth; on diagonals both axes cross texel boundaries independently, so the scene staircases ~6px and jitters. The low-res buffer is the cause, so no in-buffer trick removes it — it only relocates the artifact.

Render the buffer at native resolution instead, and move the 6x magnification from the present upscale into the camera's orthographic zoom (SCALE). Every sprite coordinate and size stays in art-pixels, so framing and zoom are unchanged, but the buffer now rasterizes at one-screen-pixel precision: the motion quantum drops 6px -> 1px and diagonals are smooth. The camera snaps to whole screen pixels (1/SCALE of an art-pixel) so static tiles stay crisp. Source art is already nearest-sampled, so the magnification stays sharp; the present pass is now a 1:1 copy (its anti-aliased sampling remains as a graceful fallback for transient resize-frame size mismatches).

Trade-off: pixel edges are now crisp nearest-neighbour blocks rather than the upscale's soft anti-aliasing — chosen deliberately in favour of smooth motion.


Claude-Session: https://claude.ai/code/session_011qWPrPf7gNMsWtKQATT4ym